### PR TITLE
[2/X] Store chart data in database

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/ActivityDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ActivityDataServlet.java
@@ -23,7 +23,7 @@ public class ActivityDataServlet extends HttpServlet {
   private static final String ACTIVITY_OBJ = "Activity";
   private static final String ACTIVITY = "activity";
   private static final String ACTIVITY_COUNT = "count";
-  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+  private static final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /* Retrieves user inputted chart data*/
   @Override

--- a/portfolio/src/main/java/com/google/sps/servlets/ActivityDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ActivityDataServlet.java
@@ -1,5 +1,13 @@
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.HashMap;
@@ -12,20 +20,46 @@ import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/activity-data")
 public class ActivityDataServlet extends HttpServlet {
-  private Map<String, Integer> activityVotes = new HashMap<>();
+  private static final String ACTIVITY_OBJ = "Activity";
+  private static final String ACTIVITY = "activity";
+  private static final String ACTIVITY_COUNT = "count";
+  
 
+  // write javadoc
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    PreparedQuery results = datastore.prepare(new Query(ACTIVITY_OBJ));
+    Map<String, Long> activityVotes = new HashMap<>();
+    for (Entity entity : results.asIterable()) {
+      String activityName = (String) entity.getProperty(ACTIVITY);
+      long count = (long) entity.getProperty(ACTIVITY_COUNT);
+
+      if (activityVotes.containsKey(activityName)) {
+        activityVotes.put(activityName, activityVotes.get(activityName) + count);
+      } else {
+        activityVotes.put(activityName, count);
+      }
+    }
+
     response.setContentType("application/json");
     response.getWriter().println(new Gson().toJson(activityVotes));
   }
 
+  /** Takes single activity input and writes into database*/
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String activity = request.getParameter("activity");
-    int currentVotes = activityVotes.containsKey(activity) ? activityVotes.get(activity) : 0;
-    activityVotes.put(activity, currentVotes + 1);
-
+    writeToDatastore(request.getParameter(ACTIVITY));
     response.sendRedirect("/fun-features.html");
+  }
+
+  private void writeToDatastore(String activity) {
+    Entity activityEntity = new Entity(ACTIVITY_OBJ);
+    activityEntity.setProperty(ACTIVITY, activity);
+    activityEntity.setProperty(ACTIVITY_COUNT, 1);
+    
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(activityEntity);
   }
 }

--- a/portfolio/src/main/webapp/fun-features.html
+++ b/portfolio/src/main/webapp/fun-features.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <title>Yichen Yao</title>
     <script src="https://www.gstatic.com/charts/loader.js"></script>
-    <script src="script.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyADFoK-nIAnOsAJfSOTC0I_0_lH68vFT-A"></script>
     <link rel="stylesheet" href="style.css" />

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -133,8 +133,8 @@ function drawChart() {
         const data = new google.visualization.DataTable();
         data.addColumn('string', 'Activity');
         data.addColumn('number', 'Votes');
-        Object.keys(activityVotes).forEach((activity) => {
-          data.addRow([activity, activityVotes[activity]]);
+        Object.keys(activityVotes).forEach((activityName) => {
+          data.addRow([activityName, activityVotes[activityName]]);
         });
         const options = {
           'title': 'Favorite Activities',


### PR DESCRIPTION
Store all user chart data in database so every vote is always counted (even when server restarted)

![KbNTrp1VWnN](https://user-images.githubusercontent.com/21322320/86978835-718a1380-c145-11ea-939e-ba575d276650.png)

Note: all chart data is inserted as individual entity (not in the same one by key) because in the future, I want to attach the person's name to their vote.