### PR TITLE
Implement query() to give possible schedule times

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -48,7 +48,7 @@ public final class FindMeetingQuery {
 
   // merges intervals of overlapping events
   private List<TimeRange> mergeIntervals(List<TimeRange> intervals) {
-    if (intervals == null || intervals.size() <= 1) {
+    if (intervals.isEmpty() || intervals.size() <= 1) {
       return intervals;
     }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,73 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
+/** Finds possible meeting times for a request for all mandatory participants */
 public final class FindMeetingQuery {
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
-  }
+
+    /**
+    * @param events List of all known events with times and participants
+    * @param request Meeting to be planned
+    * @return List of all possible meeting times
+    */
+    public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+        List<TimeRange> busyTimes = getBusyTimes(events, request);
+        Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
+        busyTimes = mergeIntervals(busyTimes);
+        return getAvailableTimes(busyTimes, request.getDuration());
+    }
+
+    // gets busy times for all request attendees
+    private ArrayList<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
+        ArrayList<TimeRange> busyTimes = new ArrayList<>();
+        for (Event event: events) {
+            for (String attendees: request.getAttendees()) {
+                if (event.getAttendees().contains(attendees)) {
+                    busyTimes.add(event.getWhen());
+                }
+            }
+        }
+        
+        return busyTimes;
+    }
+
+    // merges overlapping intervals
+    private List<TimeRange> mergeIntervals(List<TimeRange> intervals) {
+    List<TimeRange> result = new ArrayList<>();
+    for (int i = 0; i < intervals.size(); i++) {
+        TimeRange currentRange = intervals.get(i);
+        while (i + 1 < intervals.size() && currentRange.overlaps(intervals.get(i + 1))) {
+        // Combine the two overlapping Timeintervals into a single TimeRange
+        currentRange = TimeRange.fromStartEnd(currentRange.start(),
+            Math.max(currentRange.end(), intervals.get(i + 1).end()),
+            /* inclusive=*/false);
+        i++;
+        }
+        result.add(currentRange);
+    }
+    return result;
+    }
+
+    //gets available times of correct duration
+    private List<TimeRange> getAvailableTimes(List<TimeRange> busyTimes, long duration){
+    List<TimeRange> availableTimes = new ArrayList<>();
+
+    int currentStart = TimeRange.START_OF_DAY;
+    for (TimeRange time: busyTimes) {
+        if (time.start() - currentStart >= duration) {
+            availableTimes.add(TimeRange.fromStartEnd(currentStart, time.start(), /* inclusive=*/ false));
+        }
+        currentStart = time.end();
+    }
+
+    if (TimeRange.END_OF_DAY - currentStart >= duration) {
+        availableTimes.add(TimeRange.fromStartEnd(currentStart, TimeRange.END_OF_DAY, /* inclusive=*/ true));
+    }
+    return availableTimes;
+    }
+  
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -34,8 +34,8 @@ public final class FindMeetingQuery {
   }
 
   // gets busy times for all request attendees
-  private ArrayList<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
-    ArrayList<TimeRange> busyTimes = new ArrayList<>();
+  private List<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
+    List<TimeRange> busyTimes = new ArrayList<>();
     for (Event event : events) {
       for (String attendees : request.getAttendees()) {
         if (event.getAttendees().contains(attendees)) {
@@ -59,7 +59,7 @@ public final class FindMeetingQuery {
       // if events overlap, merge
       if (currentInterval.start() <= startInterval.end()) {
         startInterval = TimeRange.fromStartEnd(startInterval.start(),
-            Math.max(currentInterval.end(), startInterval.end()), /* inclusive=*/false);
+            Math.max(currentInterval.end(), startInterval.end()), /*inclusive=*/false);
       } else {
         result.add(startInterval);
         startInterval = currentInterval;
@@ -78,7 +78,7 @@ public final class FindMeetingQuery {
     for (TimeRange time : busyTimes) {
       if (time.start() - currentStart >= duration) {
         availableTimes.add(
-            TimeRange.fromStartEnd(currentStart, time.start(), /* inclusive=*/false));
+            TimeRange.fromStartEnd(currentStart, time.start(), /*inclusive=*/false));
       }
       currentStart = time.end();
     }
@@ -86,7 +86,7 @@ public final class FindMeetingQuery {
     // finds gap of requested duration time between last meeting and end of day
     if (TimeRange.END_OF_DAY - currentStart >= duration) {
       availableTimes.add(
-          TimeRange.fromStartEnd(currentStart, TimeRange.END_OF_DAY, /* inclusive=*/true));
+          TimeRange.fromStartEnd(currentStart, TimeRange.END_OF_DAY, /*inclusive=*/true));
     }
     return availableTimes;
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -21,66 +21,73 @@ import java.util.List;
 
 /** Finds possible meeting times for a request for all mandatory participants */
 public final class FindMeetingQuery {
+  /**
+   * @param events List of all known events with times and participants
+   * @param request Meeting to be planned
+   * @return List of all possible meeting times
+   */
+  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+    List<TimeRange> busyTimes = getBusyTimes(events, request);
+    Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
+    busyTimes = mergeIntervals(busyTimes);
+    return getAvailableTimes(busyTimes, request.getDuration());
+  }
 
-    /**
-    * @param events List of all known events with times and participants
-    * @param request Meeting to be planned
-    * @return List of all possible meeting times
-    */
-    public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-        List<TimeRange> busyTimes = getBusyTimes(events, request);
-        Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
-        busyTimes = mergeIntervals(busyTimes);
-        return getAvailableTimes(busyTimes, request.getDuration());
-    }
-
-    // gets busy times for all request attendees
-    private ArrayList<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
-        ArrayList<TimeRange> busyTimes = new ArrayList<>();
-        for (Event event: events) {
-            for (String attendees: request.getAttendees()) {
-                if (event.getAttendees().contains(attendees)) {
-                    busyTimes.add(event.getWhen());
-                }
-            }
+  // gets busy times for all request attendees
+  private ArrayList<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
+    ArrayList<TimeRange> busyTimes = new ArrayList<>();
+    for (Event event : events) {
+      for (String attendees : request.getAttendees()) {
+        if (event.getAttendees().contains(attendees)) {
+          busyTimes.add(event.getWhen());
         }
-        
-        return busyTimes;
+      }
+    }
+    return busyTimes;
+  }
+
+  // merges intervals of overlapping events
+  private List<TimeRange> mergeIntervals(List<TimeRange> intervals) {
+    if (intervals == null || intervals.size() <= 1) {
+      return intervals;
     }
 
-    // merges overlapping intervals
-    private List<TimeRange> mergeIntervals(List<TimeRange> intervals) {
     List<TimeRange> result = new ArrayList<>();
-    for (int i = 0; i < intervals.size(); i++) {
-        TimeRange currentRange = intervals.get(i);
-        while (i + 1 < intervals.size() && currentRange.overlaps(intervals.get(i + 1))) {
-        // Combine the two overlapping Timeintervals into a single TimeRange
-        currentRange = TimeRange.fromStartEnd(currentRange.start(),
-            Math.max(currentRange.end(), intervals.get(i + 1).end()),
-            /* inclusive=*/false);
-        i++;
-        }
-        result.add(currentRange);
+    TimeRange startInterval = intervals.get(0);
+    for (int i = 1; i < intervals.size(); i++) {
+      TimeRange currentInterval = intervals.get(i);
+      // if events overlap, merge
+      if (currentInterval.start() <= startInterval.end()) {
+        startInterval = TimeRange.fromStartEnd(startInterval.start(),
+            Math.max(currentInterval.end(), startInterval.end()), /* inclusive=*/false);
+      } else {
+        result.add(startInterval);
+        startInterval = currentInterval;
+      }
     }
+    result.add(startInterval);
     return result;
-    }
+  }
 
-    //gets available times of correct duration
-    private List<TimeRange> getAvailableTimes(List<TimeRange> busyTimes, long duration){
+  // gets available times of correct duration
+  private List<TimeRange> getAvailableTimes(List<TimeRange> busyTimes, long duration) {
     List<TimeRange> availableTimes = new ArrayList<>();
 
+    // finds gaps of requested duration time
     int currentStart = TimeRange.START_OF_DAY;
-    for (TimeRange time: busyTimes) {
-        if (time.start() - currentStart >= duration) {
-            availableTimes.add(TimeRange.fromStartEnd(currentStart, time.start(), /* inclusive=*/ false));
-        }
-        currentStart = time.end();
+    for (TimeRange time : busyTimes) {
+      if (time.start() - currentStart >= duration) {
+        availableTimes.add(
+            TimeRange.fromStartEnd(currentStart, time.start(), /* inclusive=*/false));
+      }
+      currentStart = time.end();
     }
 
+    // finds gap of requested duration time between last meeting and end of day
     if (TimeRange.END_OF_DAY - currentStart >= duration) {
-        availableTimes.add(TimeRange.fromStartEnd(currentStart, TimeRange.END_OF_DAY, /* inclusive=*/ true));
+      availableTimes.add(
+          TimeRange.fromStartEnd(currentStart, TimeRange.END_OF_DAY, /* inclusive=*/true));
     }
     return availableTimes;
-    }
-  
+  }
 }


### PR DESCRIPTION
Finished this task:
Imagine you're working on the calendar team and are responsible for adding the "find a meeting" feature. Using the existing API, you'll need to implement a feature `query()` that given the meeting information, it will return the times when the meeting could happen that day.

`query()` passes all 21 tests in FindMeetingQueryTests.java
![xxAdiGBNbNj](https://user-images.githubusercontent.com/21322320/87366966-96b0c480-c53f-11ea-9eb5-7f07b3d29dfc.png)

'If you have time left over this week and you're looking for a challenge: What's the algorithmic complexity of your algorithm?'
Time complexity: O(mlogm) + O(mn) + O(m) + O(m) --> O(mn) where m = size of `Collection<Event>` events, n = size of `request.getAttendees()`
`Collections.sort(): `O(mlogm)
`getBusyTimes():` O(mn), 2 for loops to loop through all events and attendees
`mergeIntervals():` O(m). goes through all events to merge intervals
`getAvailableTimes()`: O(m): goes through all event times to find available times
