### PR TITLE
Add scheduling for optional attendees with tests

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -51,12 +51,8 @@ public final class FindMeetingQuery {
 
   // Gets busy times for all request attendees depending on if there are optional attendees
   private List<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request, boolean isMandatory, List<TimeRange> toAppend) {
-      Collection<String> attendeeType;
-    if (isMandatory) {
-        attendeeType = request.getAttendees();
-    } else {
-        attendeeType= request.getOptionalAttendees();
-    }
+    Collection<String> attendeeType = isMandatory ? request.getAttendees: request.getOptionalAttendees;
+    
     List<TimeRange> busyTimes = new ArrayList<>();
     for (Event event : events) {
       for (String attendees : attendeeType) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -27,7 +27,7 @@ public final class FindMeetingQuery {
    * @return List of all possible meeting times
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    List<TimeRange> mandatoryBusyTimes = getBusyTimes(events, request, "mandatory", Collections.emptyList());
+    List<TimeRange> mandatoryBusyTimes = getBusyTimes(events, request, /*isMandatory=*/true, Collections.emptyList());
     List<TimeRange> mandatoryResult = getAvailableTimes(mandatoryBusyTimes, request.getDuration());
 
     // If no optional attendees, account for mandatory attendees only
@@ -36,7 +36,7 @@ public final class FindMeetingQuery {
     }
 
     // If there are optional attendees, account for them in schedule
-    List<TimeRange> optionalBusyTimes = getBusyTimes(events, request, "optional", mandatoryBusyTimes);
+    List<TimeRange> optionalBusyTimes = getBusyTimes(events, request, /*isMandatory=*/false, mandatoryBusyTimes);
     List<TimeRange> result = getAvailableTimes(optionalBusyTimes, request.getDuration());
  
     // If optional attendee scheduling conflicts with mandatory scheduling, schedule
@@ -50,9 +50,9 @@ public final class FindMeetingQuery {
   }
 
   // Gets busy times for all request attendees depending on if there are optional attendees
-  private List<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request, String requestType, List<TimeRange> toAppend) {
+  private List<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request, boolean isMandatory, List<TimeRange> toAppend) {
       Collection<String> attendeeType;
-    if (requestType.equals("mandatory")) {
+    if (isMandatory) {
         attendeeType = request.getAttendees();
     } else {
         attendeeType= request.getOptionalAttendees();

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -30,19 +30,23 @@ public final class FindMeetingQuery {
     List<TimeRange> mandatoryBusyTimes = getBusyTimes(events, request, "mandatory", Collections.emptyList());
     List<TimeRange> mandatoryResult = getAvailableTimes(mandatoryBusyTimes, request.getDuration());
 
-    // If there are optional attendees, account for them in schedule
-    if (!request.getOptionalAttendees().isEmpty()) {
-      List<TimeRange> optionalBusyTimes = getBusyTimes(events, request, "optional", mandatoryBusyTimes);
-      List<TimeRange> result = getAvailableTimes(optionalBusyTimes, request.getDuration());
- 
-      // If optional attendee scheduling conflicts with mandatory scheduling, schedule
-      // only for mandatory attendees 
-      if(result.isEmpty() && !request.getAttendees().isEmpty()) {
+    // If no optional attendees, account for mandatory attendees only
+    if(request.getOptionalAttendees().isEmpty()) {
         return mandatoryResult;
-      }  
-      return result;
     }
-    return mandatoryResult;
+
+    // If there are optional attendees, account for them in schedule
+    List<TimeRange> optionalBusyTimes = getBusyTimes(events, request, "optional", mandatoryBusyTimes);
+    List<TimeRange> result = getAvailableTimes(optionalBusyTimes, request.getDuration());
+ 
+    // If optional attendee scheduling conflicts with mandatory scheduling, schedule
+    // only for mandatory attendees 
+    if(result.isEmpty() && !request.getAttendees().isEmpty()) {
+      return mandatoryResult;
+    }  
+
+    // Return scheduling for optional and mandatory attendees
+    return result;
   }
 
   // Gets busy times for all request attendees depending on if there are optional attendees

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +44,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -255,7 +257,7 @@ public final class FindMeetingQueryTest {
     //
     // Events  : |--A-----| |-----A----|
     // Day     : |---------------------|
-    // Options :
+    // Options :     (None)
 
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
@@ -264,6 +266,143 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test 
+  public void allDayOptionalAttendee() {
+    // Optional attendee C who has an all-day event that conflicts with required 
+    // Events  : |--------------C--------------| Optional attendee
+    //                 |--A--|     |--B--|       Required attendees
+    // Day     : |-----------------------------|
+    // Result  : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeInbetween() {
+    // Optional attendee with event between required attendees, no overlap
+    // with mandatory attendees
+    //
+    // Events  :       |--A--|     |--B--|      Required attendees
+    //                       |--c--|            Optional attendee
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C))
+            );
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test 
+  public void notEnoughRoomOptional() {
+    // Optional attendee whose event makes schedule smaller than requested time
+    //
+    // Events  : |--A--|     |----A----| Required attendees
+    //         :       |--C--|           Optional
+    // Day     : |---------------------|
+    // Options :       |-----|         
+
+    Collection<Event> events = Arrays.asList(
+    new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Arrays.asList(PERSON_A)),
+    new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        Arrays.asList(PERSON_A)),
+    new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+        Arrays.asList(PERSON_C)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES));
+
+    Assert.assertEquals(expected, actual);  
+  }
+
+  @Test
+  public void noMandatoryWithGaps() {
+    // Two optional attendees with several gaps in their schedules
+    //
+    // Events  :   |--A--|   |--B---|    Optional attendees
+    // Day     : |---------------------|
+    // Options : |-|     |---|       |-|  
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryWithoutGaps() {
+    // Two optional attendees with no gaps in their schedules
+    //
+    // Events  :   |--A--|   
+    //         : |-----------B---------|
+    // Day     : |---------------------|
+    // Options :          (None)
+    Collection<Event> events = Arrays.asList(
+    new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+        Arrays.asList(PERSON_A)),
+    new Event("Event 2", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
+        Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -318,8 +318,7 @@ public final class FindMeetingQueryTest {
         new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_B)),
         new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_C))
-            );
+            Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
@@ -354,7 +353,7 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES));
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);  
   }
@@ -394,6 +393,7 @@ public final class FindMeetingQueryTest {
     //         : |-----------B---------|
     // Day     : |---------------------|
     // Options :          (None)
+    
     Collection<Event> events = Arrays.asList(
     new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
         Arrays.asList(PERSON_A)),


### PR DESCRIPTION
Modified `query()` to provide support for optional attendees and added testing for a variety of situations with optional attendees.

The prompt:
The basic functionality of optional attendees is that if one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots. Otherwise, return the time slots that fit just the mandatory attendees.

![xxAdiGBNbNj](https://user-images.githubusercontent.com/21322320/87485211-de962100-c5fd-11ea-91f7-92502eb104aa.png)

